### PR TITLE
Fix go build

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 			cmd := exec.Command("git", "clone", *repo.SSHURL)
 			cmd.Start()
 			ch <- true
-		}(repo)
+		}(*repo)
 	}
 
 	for i := 0; i < len(repos); i++ {


### PR DESCRIPTION
## WHY

```
$ make
rm -f cloner
go get -d -v ./...
go get golang.org/x/oauth2
go get github.com/google/go-github/github
go build
# github.com/hiroakis/cloner
./main.go:53: cannot use repo (type *github.Repository) as type github.Repository in argument to func literal
make: *** [build] Error 2
```

I can't build 😢 

## WHAT

Fix `go build`.

```
$ cloner  -org wantedly -token xxxxx
git clone git@github.com:wantedly/nginx-image-server.git
・・・・
```